### PR TITLE
Integrate PDF generation

### DIFF
--- a/backend/src/web_clipper.py
+++ b/backend/src/web_clipper.py
@@ -69,21 +69,16 @@ class WebClipper:
                     tags=tags,
                 )
 
-                base_filename = self._generate_filename(
-                    "aggregated_document", timestamp
+                markdown_info = self.file_manager.save_markdown(
+                    final_doc, timestamp, url
                 )
-                markdown_filename = f"{base_filename}.md"
-                markdown_path = os.path.join(self.output_dir, markdown_filename)
-                with open(markdown_path, "w", encoding="utf-8") as f:
-                    f.write(final_doc)
-
-                pdf_filename = f"{base_filename}.pdf"  # PDF stub
+                pdf_info = self.file_manager.save_pdf(final_doc, timestamp, url)
 
                 return {
                     "title": "Aggregated content",
                     "url": url,
-                    "markdown_path": markdown_filename,
-                    "pdf_path": pdf_filename,
+                    "markdown_path": markdown_info["relative_path"],
+                    "pdf_path": pdf_info["relative_path"],
                     "timestamp": timestamp,
                     "status": "completed",
                     "preview": (
@@ -112,19 +107,16 @@ class WebClipper:
                     tags=tags,
                 )
 
-                base_filename = self._generate_filename(title, timestamp)
-                markdown_filename = f"{base_filename}.md"
-                markdown_path = os.path.join(self.output_dir, markdown_filename)
-                with open(markdown_path, "w", encoding="utf-8") as f:
-                    f.write(final_doc)
-
-                pdf_filename = f"{base_filename}.pdf"  # PDF stub
+                markdown_info = self.file_manager.save_markdown(
+                    final_doc, timestamp, url
+                )
+                pdf_info = self.file_manager.save_pdf(final_doc, timestamp, url)
 
                 return {
                     "title": title,
                     "url": url,
-                    "markdown_path": markdown_filename,
-                    "pdf_path": pdf_filename,
+                    "markdown_path": markdown_info["relative_path"],
+                    "pdf_path": pdf_info["relative_path"],
                     "timestamp": timestamp,
                     "status": "completed",
                     "preview": (

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -20,7 +20,7 @@
 - **Phase 5**: Prepare production deployment and monitoring setup.
 
 ## Code Review Findings
-- **PDF generation** is stubbed in `WebClipper.clip` and needs integration with `FileManager.save_pdf`.
+- **PDF generation** is now integrated using `FileManager.save_pdf`.
 - **Marketing detection** (`utils/marketing_detector.py`) is unused; integrate into content processing to filter promotional sections.
 - **Semantic deduplication** (`SemanticContentCleaner`) is implemented but never applied when aggregating multiple pages.
 - **File uploads** are stored but not processed. Uploaded markdown or sitemap files should trigger clipping logic.

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -11,12 +11,12 @@
   - **Status**: Complete
 
 ### Core Development
-- [ ] **TASK-002**: Finalise clipping logic with PDF generation
+- [x] **TASK-002**: Finalise clipping logic with PDF generation
   - **Priority**: High
   - **Effort**: 4h
   - **Dependencies**: TASK-001
   - **Acceptance Criteria**: Markdown and PDF files generated for each clip
-  - **Status**: In Progress
+  - **Status**: Complete
 - [ ] **TASK-003**: Integrate marketing detection and semantic deduplication
   - **Priority**: Medium
   - **Effort**: 4h
@@ -78,10 +78,11 @@
 
 ## Progress Summary
 - **Total Tasks**: 11
-- **Completed**: 1
-- **In Progress**: 1
+- **Completed**: 2
+- **In Progress**: 0
 - **Remaining**: 9
-- **Overall Progress**: 9%
+- **Overall Progress**: 18%
 
 ## Notes
 - Tasks expanded based on code review. Progress will be tracked in future updates.
+- PDF generation integrated via `FileManager.save_pdf` completing TASK-002.


### PR DESCRIPTION
## Summary
- implement PDF saving via FileManager
- mark clipping task as complete
- update plan and tasks documentation

## Testing
- `python validate_docs.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68671acce1908321a9bec5cc891a9c21